### PR TITLE
Output multiple stac catalogs

### DIFF
--- a/bin/build-image
+++ b/bin/build-image
@@ -24,5 +24,5 @@ fi
 if [ -n "$DIND" ]; then
   docker -H $DOCKER_DAEMON_ADDR build --build-arg service_lib_dir="$SERVICE_LIB_DIR" -t ${image}:${ag} .
 else
-  docker build --build-arg service_lib_dir="$SERVICE_LIB_DIR" --network host -t ${image}:${tag} .
+  docker build --build-arg service_lib_dir="$SERVICE_LIB_DIR" --network host -t ${image}:test-multi-stac .
 fi


### PR DESCRIPTION
### Description

The Pull Request includes the following changes:

- Updated the building process for the Docker image to tag it as `test-multi-stac` when the build is not performed within a Docker-in-Docker environment.
- Added an import statement for the `ServerException` class from the `harmony.exceptions` module in the `harmony_service_example/transform.py` file.
- Added an import statement for the `Catalog` and `Item` classes from the `pystac` module in the `harmony_service_example/transform.py` file.
- Updated the `invoke` method in the `HarmonyAdapter` class in the `transform.py` file to create and populate multiple catalogs with items and return them as tuples.

These changes modify the build process of the Docker image and extend the functionality of the Harmony service example script in handling STAC catalogs and items.

Please let me know if further changes or information are needed.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the `invoke` method in `transform.py` to output multiple STAC catalogs instead of processing individual STAC items.

### Why are these changes being made?

The change is made to enhance the functionality of the service by allowing it to handle and output multiple STAC catalogs, which is more efficient and scalable for processing large datasets. This approach simplifies the code by removing the complex logic of processing individual items and instead focuses on catalog-level operations, which aligns better with the service&#x27;s intended use case.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->